### PR TITLE
change base_name to basename

### DIFF
--- a/backend/urls.py
+++ b/backend/urls.py
@@ -21,7 +21,7 @@ from shopping.views import ShoppingItemViewSet
 
 router = routers.DefaultRouter()
 router.register(
-    'shopping-item', ShoppingItemViewSet, base_name='shopping-item'
+    'shopping-item', ShoppingItemViewSet, basename='shopping-item'
 )
 
 urlpatterns = [


### PR DESCRIPTION
`base_name` was substituted with `basename` in recent django versions. For beginners which want to follow the tutorial it might be helpful if the code runs out of the box with recent django versions :)